### PR TITLE
feat(geh): Add global error handler

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,4 +1,6 @@
-import express from 'express';
+import express, { ErrorRequestHandler } from "express";
+
+import { ServerError } from "./types/types.js";
 
 //! import middleware here:
 // import { parseUserQuery } from ' file path ';
@@ -6,22 +8,40 @@ import express from 'express';
 // import { queryVectorDb } from ' file path ';
 
 const app = express();
-const PORT=3000
+const PORT = 3000;
 
 //* this will take the plain text input and change it into JSON format
 app.use(express.json());
 
-app.post('/api',
-   // parseUserQuery,
-   // queryAiEmbedding
-   // queryVectorDb,
-   // aiCompletion,
-   (_req, res) => {
-      res.status(200).json({ response: 'best team ever' });
-   }
-)
+app.post(
+  "/api",
+  // parseUserQuery,
+  // queryAiEmbedding
+  // queryVectorDb,
+  // aiCompletion,
+  (_req, res) => {
+    res.status(200).json({ response: "best team ever" });
+  }
+);
+
+const errorHandler: ErrorRequestHandler = (
+  err: ServerError,
+  _req,
+  res,
+  _next
+) => {
+  const defaultErr: ServerError = {
+    log: "Express error handler caught unknown middleware error",
+    status: 500,
+    message: { err: "An error occurred" },
+  };
+  const errorObj: ServerError = { ...defaultErr, ...err };
+  console.log(errorObj.log);
+  res.status(errorObj.status).json(errorObj.message);
+};
+
+app.use(errorHandler);
 
 app.listen(PORT, () => {
-   console.log(`Server running on http://localhost:${PORT}`);
+  console.log(`Server running on http://localhost:${PORT}`);
 });
-

--- a/server/src/types/types.ts
+++ b/server/src/types/types.ts
@@ -1,0 +1,5 @@
+export type ServerError = {
+  log: string;
+  status: number;
+  message: { err: string };
+};


### PR DESCRIPTION
Tested with sample error:

```
  return next({
    log: "This should be in console log",
    status: 400,
    message: { err: "This should be on webpage" },
  });
```

Global error handler worked as expected.