### PR TITLE
feat(query): Query upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "concurrently -n 'FRONTEND,BACKEND' -c 'cyan,magenta' 'npm run start:frontend' 'cd server; npm run express'",
+    "start:frontend": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
@@ -25,6 +26,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
+    "concurrently": "^9.2.0",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
       });
 
       const data = await res.json();
-      setOutput(data.result || 'No result returned from AI.');
+      setOutput(data.response || 'No result returned from AI.');
     } catch (err) {
       console.error(err);
       setOutput('⚠️ Error: Could not connect to AI backend.');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,10 +16,10 @@ function App() {
     setOutput('');
 
     try {
-      const res = await fetch('/api', { // this needs to be our backend url
+      const res = await fetch('/api', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: input })
+        body: JSON.stringify({ userQuery: input })
       });
 
       const data = await res.json();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ function App() {
     setOutput('');
 
     try {
-      const res = await fetch('http://localhost:5000/api/translate', { // this needs to be our backend url
+      const res = await fetch('/api', { // this needs to be our backend url
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text: input })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,8 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
+    port: 5173,
+    strictPort: true, // fail instead of switching ports
     proxy: {
       '/api': {
         target: 'http://localhost:3000',


### PR DESCRIPTION
This Pull Request will allow one to `npm run dev` to run both backend and front end:

```
$ npm run dev

> multilingo@0.0.0 dev
> concurrently -n 'FRONTEND,BACKEND' -c 'cyan,magenta' 'npm run start:frontend' 'cd server; npm run express'

[BACKEND] 
[BACKEND] > server@1.0.0 express
[BACKEND] > nodemon --watch src --ext ts,json --exec "ts-node src/server.ts"
[BACKEND] 
[FRONTEND] 
[FRONTEND] > multilingo@0.0.0 start:frontend
[FRONTEND] > vite
[FRONTEND] 
...
```

We additionally adjust the front-end and back-end contracts to match.